### PR TITLE
Steps status and symphony

### DIFF
--- a/app/assets/javascripts/activities.js
+++ b/app/assets/javascripts/activities.js
@@ -73,8 +73,8 @@
     node.trigger("load_stop.loading_spinner", {
       node: node
     });*/
-
-    var url = $('#steps_finished').data('psd-steps-update-url');
+    var url = $('#steps_finished > div').data('psd-steps-update-url');
+    //var url = null;
     $('#steps_finished').load(url, $.proxy(function() {
       $(this.form).trigger("execute.builder");
     }, this));

--- a/app/assets/javascripts/fact_searcher_lightweight.js
+++ b/app/assets/javascripts/fact_searcher_lightweight.js
@@ -29,11 +29,12 @@
     text.split(' ').forEach($.proxy(function(param, pos) {
      var list = param.split(':');
      if (list.length == 1) {
-       if (param.match(/^\d\d*$/)) {
+       list = ['barcode', param];
+      /* if (param.match(/^\d\d*$/)) {
         list = ['barcode', param];
       } else {
         list = ['is', param];
-      }
+      }*/
     }
 
     this.addHiddenInput('p'+pos, list[0]);

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -352,4 +352,7 @@ div.fact a.active.object-reference  {color:orange;}
 svg { cursor: -webkit-zoom-in; }
 svg.enlarge { cursor: -webkit-zoom-out; }
 
+.step_types_active svg ellipse { cursor: pointer;}
+.step_types_active svg { cursor: default;}
+
 .facts-list svg.enlarge { height: 150px;}

--- a/app/controllers/activities_controller.rb
+++ b/app/controllers/activities_controller.rb
@@ -65,6 +65,7 @@ class ActivitiesController < ApplicationController
   end
 
   def index
+    @my_activities = @current_user ? Activity.for_user(@current_user) : []
   end
 
 

--- a/app/controllers/steps_controller.rb
+++ b/app/controllers/steps_controller.rb
@@ -21,10 +21,11 @@ class StepsController < ApplicationController
   # GET /steps
   # GET /steps.json
   def index
-    redirect_to activities_path
-    return
+    #redirect_to activities_path
+    #return
     #@steps = Step.all
     respond_to do |format|
+      format.json { render @steps }
       format.html { render 'finished', :layout => false } if @activity
     end
   end

--- a/app/helpers/steps_helper.rb
+++ b/app/helpers/steps_helper.rb
@@ -1,3 +1,24 @@
 module StepsHelper
+  def text_color_for_state(state)
+    "text-#{color_for_state(state)}"
+  end
 
+  def color_for_state(state)
+    css = "info"
+    css = 'success' if state == 'complete'
+    css = 'danger' if state == 'error'
+    css = 'info' if state == 'running'
+    css = 'warning' if state == 'in progress'
+
+    return css
+  end
+
+  def image_for_state(state)
+    css = 'glyphicon-ok' if state == 'complete'
+    css = 'glyphicon-remove' if state == 'error'
+    css = 'glyphicon-refresh' if state == 'running'
+    css = 'glyphicon-repeat' if state == 'in progress'
+
+    return "<span class='glyphicon #{css} #{text_color_for_state(state)}'></span>".html_safe
+  end
 end

--- a/app/models/activity.rb
+++ b/app/models/activity.rb
@@ -32,6 +32,8 @@ class Activity < ActiveRecord::Base
     where(:activity_type => activity_type)
   }
 
+  scope :for_user, ->(user) { joins(:steps).where({:steps => {:user_id => user.id}}).distinct }
+
 
   class StepWithoutInputs < StandardError
   end

--- a/app/models/activity.rb
+++ b/app/models/activity.rb
@@ -109,10 +109,16 @@ class Activity < ActiveRecord::Base
     if params_for_progress_with_step?(step_params)
       unless step
         group = AssetGroup.create!
+        if step_params[:assets]
+          group.assets << step_params[:assets]
+        else
+          group.assets << asset_group.assets
+        end
         step = steps.create!(:step_type => step_type, :asset_group_id => group.id,
-          :user_id => user.id, :in_progress? => true)
+          :user_id => user.id, :in_progress? => true, :state => 'in progress')
       end
       perform_step_actions_for('progress_step', step, step_type, step_params)
+      step.progress_with(step_params)
     else
       if step && params_for_finish_step?(step_params)
         step.finish

--- a/app/models/asset/import.rb
+++ b/app/models/asset/import.rb
@@ -49,6 +49,7 @@ module Asset::Import
 
   def find_or_import_asset_with_barcode(barcode)
     asset = Asset.find_by_barcode(barcode)
+    asset = Asset.find_by_uuid(barcode) unless asset
     unless asset
       if Barcode.is_creatable_barcode?(barcode)
         asset = Asset.create!(:barcode => barcode)

--- a/app/models/asset_group.rb
+++ b/app/models/asset_group.rb
@@ -33,7 +33,7 @@ class AssetGroup < ActiveRecord::Base
 
   def unselect_barcodes(barcodes)
     barcodes.each do |barcode|
-      selection = assets.select{|a| a.barcode == barcode}
+      selection = assets.select{|a| (a.barcode == barcode) || (a.uuid == barcode)}
       assets.delete(selection)
     end
   end

--- a/app/models/background_steps/transfer_samples.rb
+++ b/app/models/background_steps/transfer_samples.rb
@@ -1,7 +1,8 @@
 class BackgroundSteps::TransferSamples < Step
 
   def assets_compatible_with_step_type
-    asset_group.assets.with_predicate('transfer').count > 0
+    #asset_group.assets.with_predicate('transfer').count > 0
+    Asset.with_predicate('transfer').count > 0
   end
 
   def execute_actions
@@ -16,21 +17,39 @@ class BackgroundSteps::TransferSamples < Step
   def background_job
     return unless assets_compatible_with_step_type
 
-    asset_group.assets.each do |asset|
+    Asset.with_predicate('transfer').each do |asset|
+
+    #asset_group.assets.each do |asset|
       asset.add_facts([Fact.new(:predicate => 'is', :object => 'Used')])
       asset.facts.with_predicate('transfer').each do |fact|
         modified_asset = fact.object_asset
         added_facts = asset.facts.with_predicate('sanger_sample_id').map do |aliquot_fact|
           [Fact.new(:predicate => 'sanger_sample_id', :object => aliquot_fact.object),
-          Fact.new(:predicate => 'sample_id', :object => aliquot_fact.object)]
+          Fact.new(:predicate => 'sample_id', :object => aliquot_fact.object)
+        ]
         end.flatten
+        added_facts.concat(asset.facts.with_predicate('aliquotType').map do |aliquot_fact|
+          [Fact.new(:predicate => 'aliquotType', :object => aliquot_fact.object)
+        ]
+        end.flatten)
+        added_facts.push(Fact.new(:predicate => 'transferredFrom', :object_asset => asset))
+
 
         modified_asset.add_facts(added_facts)
         modified_asset.add_operations(added_facts, self)
       end
+      #end
+      asset.facts.with_predicate('parent').each do |f|
+        f.object_asset.touch
+      end
+      asset.asset_groups.each(&:touch)
     end
-    asset_group.touch
+    #asset_group.touch
+
     update_attributes!(:state => 'complete')
+  ensure
+    update_attributes!(:state => 'error') unless state == 'complete'
+    asset_group.touch    
   end
 
   handle_asynchronously :background_job

--- a/app/models/fact.rb
+++ b/app/models/fact.rb
@@ -6,11 +6,13 @@ class Fact < ActiveRecord::Base
 
   scope :with_predicate, ->(predicate) { where(:predicate => predicate)}
 
+  scope :with_ns_predicate, ->(namespace) { where(:ns_predicate => namespace)}
+
   scope :with_fact, -> (predicate, object) { where(:predicate => predicate, :object => object)}
 
-  scope :with_namespace, ->(namespace) { where("predicate LIKE :namespace", namespace: "#{namespace}\#%")}
+  #scope :with_namespace, ->(namespace) { where("predicate LIKE :namespace", namespace: "#{namespace}\#%")}
 
-  scope :for_sequencescape, ->() { with_namespace('SS') }
+  #scope :for_sequencescape, ->() { with_namespace('SS') }
 
   def set_to_remove_by(step)
     update_attributes!(:to_remove_by => step)

--- a/app/views/activities/index.html.erb
+++ b/app/views/activities/index.html.erb
@@ -1,0 +1,34 @@
+<p id="notice"><%= notice %></p>
+
+<h1>My Activities <small>Index</small></h1>
+<br />
+<br />
+<% if @current_user %>
+<table class="table table-bordered">
+  <thead>
+    <tr>
+      <th>Id</th>
+      <th>Activity Type</th>
+      <th>Last update</th>
+      <th></th>
+    </tr>
+  </thead>
+
+  <tbody>
+    <% @my_activities.reverse.each do |activity| %>
+      <tr>
+        <td><%= activity.id %></td>
+        <td><%= activity.activity_type.name %></td>
+        <td><%= activity.updated_at %></td>
+        <td><%= bootstrap_link_to 'Show', activity %></td>
+        <!-- td>< %= bootstrap_link_to 'Destroy', activity_type, method: :delete, data: { confirm: 'Are you sure?' } %></td -->
+      </tr>
+    <% end %>
+  </tbody>
+</table>
+<% else %>
+No activities created for the current user
+<% end %>
+<br>
+
+

--- a/app/views/application/_user_status_navbar.html.erb
+++ b/app/views/application/_user_status_navbar.html.erb
@@ -55,9 +55,15 @@
           <div class="col-lg-8">
             <p class="text-left"><i class="role"></i></p>
           </div>
+
           <div class="col-lg-8">
             <p class="text-left">Tube printer: <i class="tube-printer"></i></p>
             <p class="text-left">Plate printer: <i class="plate-printer"></i></p>
+          </div>
+          <div class="col-lg-8">
+            <p class="text-left">
+              <%= bootstrap_link_to 'My activities', activities_path %>
+            </p>
           </div>
 
         </div>

--- a/app/views/asset_groups/_asset_group.html.erb
+++ b/app/views/asset_groups/_asset_group.html.erb
@@ -75,7 +75,7 @@
                 <%= render :partial => 'facts/facts', :locals => { :facts => asset.facts, :show_image => true, :show_facts => true } %>
               </td>
               <td>
-                <button class="btn btn-primary delete-button" data-psd-asset-group-delete-barcode="<%= asset.barcode %>">Delete</button>
+                <button class="btn btn-primary delete-button" data-psd-asset-group-delete-barcode="<%= asset.barcode ? asset.barcode : asset.uuid %>">Delete</button>
               </td>
             </tr>
           <% end %>

--- a/app/views/step_types/_step_type.html.erb
+++ b/app/views/step_types/_step_type.html.erb
@@ -23,7 +23,7 @@
   <% end %>
 </ul>
 
-<div class="step-template-view">
+<div class="step-template-view pull-left">
   <div class="tab-content">
   <% step_types.select{|s| s.step_template }.each_with_index do |step_type, index| %>
     <% unless step_type.step_template.nil? || step_type.step_template.empty? %>

--- a/app/views/step_types/step_templates/_rack_order_symphony.html.erb
+++ b/app/views/step_types/step_templates/_rack_order_symphony.html.erb
@@ -1,3 +1,3 @@
-<%= render :partial => 'upload_file_step', :locals => {:data_action => 'order_symphony',
+<%= render :partial => 'upload_file_step', :locals => {:data_action => 'samples_symphony',
   :step_type => step_type, :index => index
 } %>

--- a/app/views/steps/_steps.html.erb
+++ b/app/views/steps/_steps.html.erb
@@ -2,13 +2,13 @@
     <div class="panel-body">
       <% unless steps.count == 0 %>
       <table class="table table-condensed table-hover steps-table">
-        <thead><th>Step id</th><th>Step type</th><th>Activity id</th><th>Activity type</th><th>Username</th></thead>
+        <thead><th>Step id</th><th>Step type</th><th>Activity id</th><th>Activity type</th><th>Username</th><th>Last update</th><th>Status</th></thead>
         <tbody>
-          <% steps.each do |step| %>
-            <tr data-toggle="collapse" data-target="#step-<%= step.id %>" data-psd-step-id="<%= step.id %>" class="clickable info"><td><%= step.id %></td><td><%= step.step_type.name %></td><td><%= step.activity.id %></td><td><%= step.activity.activity_type.name %></td><td><%= step.user.username %></td></tr>
+          <% steps.reverse.each do |step| %>
+            <tr data-toggle="collapse" data-target="#step-<%= step.id %>" data-psd-step-id="<%= step.id %>" class="clickable  <%= color_for_state(step.state) %>"><td><%= step.id %></td><td><%= step.step_type.name %></td><td><%= step.activity.id %></td><td><%= step.activity.activity_type.name %></td><td><%= step.user.username %></td><td><%= step.updated_at %><td style="text-align:center;"><%= image_for_state(step.state) %></td></tr>
 
             <tr class="operations">
-              <td colspan="5">
+              <td colspan="7">
                 <div id="step-<%= step.id %>" class="collapse <%= 'in' if params[:step_id].to_i==step.id %>">
                   <% unless @in_steps_finished %>
 

--- a/db/migrate/20170128170039_add_namespace_to_fact_predicate.rb
+++ b/db/migrate/20170128170039_add_namespace_to_fact_predicate.rb
@@ -1,0 +1,7 @@
+class AddNamespaceToFactPredicate < ActiveRecord::Migration
+  def change
+    ActiveRecord::Base.transaction do |t|
+      add_column :facts, :ns_predicate, :string
+    end    
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20170122173205) do
+ActiveRecord::Schema.define(version: 20170128170039) do
 
   create_table "actions", force: :cascade do |t|
     t.string   "action_type",                limit: 255, null: false
@@ -188,6 +188,7 @@ ActiveRecord::Schema.define(version: 20170122173205) do
     t.datetime "created_at",                                  null: false
     t.datetime "updated_at",                                  null: false
     t.integer  "position",        limit: 4
+    t.string   "ns_predicate",    limit: 255
   end
 
   add_index "facts", ["asset_id"], name: "index_facts_on_asset_id", using: :btree

--- a/features/operator/tracking_labware.feature
+++ b/features/operator/tracking_labware.feature
@@ -103,12 +103,10 @@ When I use the browser to enter in the application
 Then I should see the Instruments page
 
 Scenario: Create a new activity with some assets
-When I log in as "Charles"
+When I go to the Instruments page
+And I log in as "Charles"
 Then I am logged in as "Charles"
-When I go to the Instruments page
-And I am logged in as "Charles"
-When I go to the Instruments page
-And I create an activity with instrument "My Instrument" and kit "1"
+Then I create an activity with instrument "My Instrument" and kit "1"
 Then I should have created an empty activity for "Tubes to rack"
 
 When I scan these barcodes into the selection basket:

--- a/features/step_definitions/basic_definitions.rb
+++ b/features/step_definitions/basic_definitions.rb
@@ -133,9 +133,11 @@ end
 
 Then(/^I should ?(not)? have performed the step "([^"]*)" with the user "([^"]*)"$/) do |not_action, step_name, username|
   # table is a Cucumber::MultilineArgument::DataTable
-  expect(all("#steps_finished .panel tr").any? do |elem|
-    elem.has_content?(step_name) && elem.has_content?(username)
-  end).to eq(not_action != 'not')
+  expect(find("#steps_finished .panel tbody tr:first-child").has_content?(step_name) &&
+  find("#steps_finished .panel tbody tr:first-child").has_content?(username)).to eq(not_action != 'not')
+  #expect(find("#steps_finished .panel tr").any? do |elem|
+  #  elem.has_content?(step_name) && elem.has_content?(username)
+  #end).to eq(not_action != 'not')
 end
 
 When(/^I open the operations list$/) do

--- a/lib/parsers/csv_layout.rb
+++ b/lib/parsers/csv_layout.rb
@@ -30,7 +30,6 @@ module Parsers
     end
 
     def builder(barcode)
-      barcode.strip!
       if create_tubes?
         asset = Asset.find_by_barcode(barcode)
         asset = Asset.create!(:barcode => barcode) unless asset
@@ -47,7 +46,7 @@ module Parsers
 
     def parse
       @data ||= @csv_parser.to_a.map do |line|
-        location, barcode = line[0], line[1]
+        location, barcode = line[0].strip, line[1].strip
         asset = builder(barcode)
         @errors.push(:msg => "Invalid location") unless valid_location?(location)
         @errors.push(:msg => "Cannot find the barcode #{barcode}") if asset.nil?
@@ -75,6 +74,10 @@ module Parsers
     def valid?
       parse unless @parsed
       @data && @errors.empty?
+    end
+
+    def layout
+      @data
     end
 
 

--- a/lib/parsers/symphony.rb
+++ b/lib/parsers/symphony.rb
@@ -1,67 +1,108 @@
 require 'pry'
 module Parsers
   class Symphony
+    SYMPHONY_NAMESPACE = 'Symphony'
+
+    attr_accessor :error_messages
     attr_reader :doc
     def initialize(str)
+      @error_messages = []
       @doc = Nokogiri::XML(str)
     end
 
     def self.valid_for?(str)
-      return Nokogiri::XML(str).xpath("Rack").count == 1
+      return Nokogiri::XML(str).xpath("FullPlateTrack").count == 1
     end
 
-    def to_assets
-      @doc.xpath("/Rack//RackPosition").map do |rack_position|
-        facts = ["SampleId", "PositionName", "TotalVolumeInUl"].map do |name|
-          value = rack_position.at_xpath(name).text
-          if name == "PositionName"
-            value = value.gsub!(':','')
+    def tube_at_location(rack, location)
+      tubes = rack.facts.with_predicate('contains').map(&:object_asset)
+      return nil if tubes.empty?
+      tubes.select {|t| t.facts.with_fact('location', location).count > 0}.first
+    end
+
+    def apply_to_rack(rack)
+      apply_symphony_facts_to_rack(rack)
+      reasoning_with_symphony_facts(rack)
+    end
+
+    def reasoning_with_symphony_facts(rack)
+      #
+      #  {
+      #   ?rack :contains ?tubeInRack .
+      #   ?tubeInRack Symphony:SampleCode ?barcode .
+      #   ?tubePrevious :barcode ?barcode 
+      #  } => {
+      #   :step :addFacts { ?tubePrevious :transfer ?tubeInRack . }.
+      #   :step :removeFacts { ?tubeInRack Symphony:SampleCode ?barcode . } .
+      #  } .
+      #  {
+      #   ?rack :contains ?tubeInRack .
+      #   ?tubeInRack Symphony:SampleOutputVolume ?volume .
+      #  } => {
+      #   :step :addFacts { ?tubeInRack :volume ?volume . } .
+      #   :step :removeFacts { ?tubeInRack Symphony:SampleOutputVolume ?volume . } .
+      #  } .
+      #
+      tubes = rack.facts.with_predicate('contains').map(&:object_asset)
+      tubes.each do |tube|
+        tube.facts.with_ns_predicate(Parsers::Symphony::SYMPHONY_NAMESPACE).each do |f|
+          if f.predicate == 'SampleCode'
+            asset = Asset.find_or_import_asset_with_barcode(f.object)
+            asset.add_facts([
+              Fact.create(:predicate => 'transfer', :object_asset => tube)
+            ])
+            tube.add_facts([
+              Fact.create(:predicate => 'transferredFrom', :object_asset => asset)
+            ])
+          elsif f.predicate == 'SampleOutputVolume'
+            tube.add_facts([
+              Fact.create(:predicate => 'volume', :object => f.object)
+            ])
           end
-          Fact.new(:predicate => 'Symphony:'+name,
-            :object => value
-            )
+          f.destroy
         end
-        asset = Asset.new
-        asset.add_facts(facts)
-        asset
       end
     end
 
-    def add_assets(asset)
-      #to_assets.each do |a|
-      #  asset.facts << Fact.create(:predicate => "Symphony:RackPosition", :object_asset_id => a.id)
-      #end
-      #asset.reasoning!
-      connect_tubes!(asset)
+    def apply_symphony_facts_to_rack(rack)
+      @doc.xpath("//SampleTrack").map do |sample_track|
+        facts = ["SampleCode", "SampleOutputPos", "SampleOutputVolume"].map do |name|
+          value = sample_track.at_xpath(name).text
+          if name == "SampleOutputPos"
+            value = value.gsub!(':','')
+          end
+          Fact.new({
+            :predicate => name,
+            :object => value,
+            :ns_predicate => Parsers::Symphony::SYMPHONY_NAMESPACE
+          })
+        end
+        asset_location = facts.select do |f| 
+          f.predicate == 'SampleOutputPos' && 
+          f.ns_predicate == Parsers::Symphony::SYMPHONY_NAMESPACE
+        end.first.object
+
+        asset = tube_at_location(rack, asset_location)
+        if asset.nil?
+          add_error("No tube present at location #{asset_location}. Transfer cannot be created.")
+        end
+        asset.add_facts(facts) if asset
+      end
+    end
+
+    def add_error(msg)
+      @error_messages.push(msg)
+    end
+
+    def self.parse(content, rack)
+      @parser = Parsers::Symphony.new(content)
+      @parser.apply_to_rack(rack)
+      @parser.error_messages
     end
 
     def location_to_index(location)
       letter, num = location[0], location[1]
       (('A'..'F').find_index(location[0]) * 12) + (location[1].to_i - 1)
     end
-
-    def predicated_with(facts, predicate)
-      facts.select{|f| f.predicate == predicate}
-    end
-
-    def connect_tubes!(rack)
-      tubes = predicated_with(rack.facts,'contains').map{|f| f.object_asset}
-      to_assets.each do |position_asset|
-        rack_position_facts = position_asset.facts
-        posName = predicated_with(rack_position_facts, 'Symphony:PositionName').first.object
-        if posName
-          tube = tubes.select{|tube| tube.facts.with_fact('location', posName).count!=0}.first
-          if tube
-            tube.add_facts(rack_position_facts)
-            tube.add_facts(predicated_with(rack_position_facts, 'Symphony:TotalVolumeInUl').map do |f|
-              f2 = f.dup
-              f2.predicate = 'measured_volume'
-              f2
-            end)
-          end
-        end
-      end
-    end
-
   end
 end

--- a/spec/lib/parsers/symphony_spec.rb
+++ b/spec/lib/parsers/symphony_spec.rb
@@ -1,0 +1,44 @@
+require 'rails_helper'
+require 'parsers/symphony'
+
+RSpec.describe Parsers::Symphony do
+
+  describe "parses a symphony file" do
+    setup do
+      @content = File.open('test/data/symphony.xml')
+      @rack = FactoryGirl.create(:asset)
+      @tube = FactoryGirl.create(:asset)
+      @barcode = '11111111'
+      @tube_orig = FactoryGirl.create(:asset, { :barcode => @barcode})
+      @rack.add_facts(FactoryGirl.create(:fact, {
+        :predicate => 'contains',
+        :object_asset => @tube
+        }))
+      @tube.add_facts(FactoryGirl.create(:fact, {
+        :predicate => 'location',
+        :object => 'A1'
+        }))
+
+    end
+
+    describe "with valid content" do
+      it 'validates the file' do
+        expect(Parsers::Symphony.valid_for?(@content)).to eq(true)
+      end
+
+      it 'loads data correctly' do
+        msgs = Parsers::Symphony.parse(@content, @rack)
+
+        expect(msgs).to eq([])
+
+        tubes = @rack.facts.with_predicate('contains').map(&:object_asset)
+
+        tube = tubes.select{|tube| tube.facts.with_predicate('location').first.object == 'A1'}.first
+        orig_tube = tube.facts.with_predicate('transferredFrom').first.object_asset
+
+        expect(orig_tube.barcode).to eq(@barcode)
+      end
+    end
+
+  end
+end

--- a/test/data/symphony.xml
+++ b/test/data/symphony.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<FullPlateTrack Type="Object" Class ="FullPlateTrack">
+  <SampleTrack Type="Object" Class ="SampleTrack">
+   <SampleOutputVolume Type="CVolume">110.0</SampleOutputVolume>
+   <SampleCode Type="String">11111111</SampleCode>
+   <SamplePosition Type="String">1</SamplePosition>
+   <SampleOutputPos Type="String">A:1</SampleOutputPos>
+  </SampleTrack>
+</FullPlateTrack>


### PR DESCRIPTION
	Delete assets without a barcode:  …
 - Allow to find and remove assets by uuid in the barcode input
Status of steps:
 - Steps list shown in reverse order
 - Last update and status of the step with a color describing if it is
   running, in progress, completed or with error.
Racking:
 - Racking process now uses the same code while parsing .csv layout or
racking by user interaction
 - Contents of rack is totally remove while providing a new layout
Symphony:
 - Added symphony parser
 - Added namespace of predicates for facts so we can perform search of
predicates under the Symphony namespace
Printing:
 - Some data accessors to allow printing from background jobs
Background jobs:
 - Some refactors
 - Transfer job will happen for all the assets, not just the assets of the
current step
	Added view of my activities in activities index
	Reracking new checks:  …
- Clashes of locations between former rack content and new layout
- Missing tubes. Tubes should always be in another rack, they cannot be
interchangeable