### PR TITLE
Added runtime evaluable conditions for checks that can only be performed

### DIFF
--- a/app/controllers/activities_controller.rb
+++ b/app/controllers/activities_controller.rb
@@ -44,7 +44,6 @@ class ActivitiesController < ApplicationController
   end
 
   def update
-    select_assets
     select_assets_grouped
 
     @activity.finish unless params[:finish].nil?

--- a/app/controllers/activities_controller.rb
+++ b/app/controllers/activities_controller.rb
@@ -2,7 +2,12 @@ class ActivitiesController < ApplicationController
   include ActionController::Live
 
   before_action :set_activity, only: [:show, :update, :step_types_active, :steps_finished, :steps_finished_with_operations]
-  before_action :select_assets, only: [:show, :update, :step_types_active, :steps_finished, :steps_finished_with_operations]
+  before_action :set_asset_group, only: [:show, :update, :step_types_active, :steps_finished, :steps_finished_with_operations]
+  before_action :set_assets, only: [:show, :update, :step_types_active, :steps_finished, :steps_finished_with_operations]
+
+  before_action :set_activity_type, only: [:create_without_kit]
+
+  
   before_action :select_assets_grouped, only: [:show, :update, :step_types_active, :steps_finished, :steps_finished_with_operations]
 
   before_action :set_kit, only: [:create]
@@ -13,7 +18,7 @@ class ActivitiesController < ApplicationController
   before_action :set_uploaded_files, only: [:update]
   #before_action :set_params_for_step_in_progress, only: [:update]
 
-  before_action :set_activity_type, only: [:create_without_kit]
+  
 
   #before_filter :session_authenticate, only: [:update, :create]
 
@@ -178,8 +183,15 @@ class ActivitiesController < ApplicationController
     # Use callbacks to share common setup or constraints between actions.
     def set_activity
       @activity = Activity.find(params[:id])
+    end
+
+    def set_asset_group
       @asset_group = @activity.asset_group
     end
+
+  def set_assets
+    @assets = @asset_group.assets.includes(:facts)
+  end    
 
     # Never trust parameters from the scary internet, only allow the white list through.
     def activity_params
@@ -187,10 +199,6 @@ class ActivitiesController < ApplicationController
     end
 
 
-  def select_assets
-    @assets = @activity.asset_group.assets.includes(:facts)
-
-  end
 
   def select_assets_grouped
     @assets_grouped = assets_by_fact_group

--- a/app/models/asset.rb
+++ b/app/models/asset.rb
@@ -10,6 +10,9 @@ class Asset < ActiveRecord::Base
   extend Asset::Import
   include Asset::Export
 
+
+  alias_attribute :name, :barcode 
+
   has_many :facts
   has_and_belongs_to_many :asset_groups
   has_many :steps, :through => :asset_groups
@@ -109,7 +112,7 @@ class Asset < ActiveRecord::Base
         end
       end
     end
-    touch
+    touch unless new_record?
   end
 
 

--- a/app/models/condition.rb
+++ b/app/models/condition.rb
@@ -57,7 +57,27 @@ class Condition < ActiveRecord::Base
     return object_condition_group && object_condition_group.is_wildcard?
   end
 
+  def runtime_compatible_with?(asset, related_asset)
+    if (predicate == 'equalTo')
+      return asset == related_asset
+    end
+    if (predicate == 'notEqualTo')
+      return asset != related_asset
+    end
+    if (predicate == 'hasNotPredicate')
+      return asset.facts.with_predicate(object).count == 0
+    end
+    if (predicate == 'sum')
+      return asset.facts.with_predicate(object).count == 0
+    end    
+  end
+
+  def is_runtime_evaluable_condition?
+    (predicate == 'equalTo') || (predicate == 'notEqualTo') || (predicate == 'hasNotPredicate') || (predicate == 'sum')
+  end
+
   def compatible_with?(asset, related_assets = [], checked_condition_groups=[], wildcard_values = {})
+    return true if is_runtime_evaluable_condition?
     return false if asset.nil?
     return check_wildcard_condition(asset, wildcard_values) if is_wildcard_condition?
     asset.facts.any? do |fact|

--- a/app/models/condition_group.rb
+++ b/app/models/condition_group.rb
@@ -26,6 +26,20 @@ class ConditionGroup < ActiveRecord::Base
     end
   end
 
+  def has_runtime_conditions?
+    runtime_conditions.count > 0
+  end
+
+  def runtime_conditions
+    conditions.select{|c| c.is_runtime_evaluable_condition?}    
+  end
+
+  def runtime_conditions_compatible_with?(asset, related_asset)
+    runtime_conditions.all? do |c|
+      c.runtime_compatible_with?(asset,related_asset)
+    end
+  end
+
   def conditions_compatible_with?(assets, related_assets = [])
     [assets].flatten.all? do |asset|
       conditions.all? do |condition|

--- a/app/models/step_execution.rb
+++ b/app/models/step_execution.rb
@@ -86,6 +86,7 @@ class StepExecution
   end
 
   def perform_action(action, asset, position)
+    #puts "action=#{action.action_type}, asset=#{asset.name}, position=#{position}"
     @asset = asset
     @position = position
     @action = action

--- a/features/operator/background_steps.feature
+++ b/features/operator/background_steps.feature
@@ -96,6 +96,10 @@ Then I should see these barcodes in the selection basket:
 | Barcode |
 | 1       |
 
+Then I should see these steps available:
+| Step                    |
+| Create new tube with any aliquot       |
+
 And I perform the step "Create new tube with any aliquot"
 
 Then I should have created an asset with the following facts:

--- a/features/step_definitions/basic_definitions.rb
+++ b/features/step_definitions/basic_definitions.rb
@@ -198,6 +198,7 @@ Then(/^I should not see any steps available$/) do
 end
 
 When(/^I finish the activity$/) do
+  expect(page.has_content?("Finish activity?"))
   click_on('Finish activity?')
 end
 

--- a/lib/label_templates/ss_tube.rb
+++ b/lib/label_templates/ss_tube.rb
@@ -7,7 +7,7 @@ def tube_barcode_definition(name, type_id, barcode_type)
     name: name,
     label_type_id: type_id, # Tube
     labels_attributes:[{
-      name: 'main_label',
+      name: 'label',
       bitmaps_attributes:[
         {"horizontal_magnification":"05","vertical_magnification":"05","font":"H","space_adjustment":"03","rotational_angles":"11",
       "x_origin":"0038","y_origin":"0210","field_name":"bottom_line"},

--- a/spec/integration/inference_spec.rb
+++ b/spec/integration/inference_spec.rb
@@ -1,0 +1,119 @@
+require 'rails_helper'
+require 'integration/inferences_data'
+
+def assets_equal?(expected, obtained)
+  return false if expected.nil? || obtained.nil?
+
+  [[expected, obtained], 
+    [obtained, expected]].all? do |expected_assets, obtained_assets|
+    expected_assets.all? do |expected_asset|
+      obtained_assets.any? do |obtained_asset|
+        next if expected_asset.name != obtained_asset.name
+        obtained_asset.facts.reload.all? do |obtained_asset_fact|
+          expected_asset.facts.reload.any? do |expected_asset_fact|
+            val = (obtained_asset_fact.predicate == expected_asset_fact.predicate)
+            unless obtained_asset_fact.object_asset.nil?
+              val && (obtained_asset_fact.object_asset.name == expected_asset_fact.object_asset.name)
+            else
+              val && (obtained_asset_fact.object == expected_asset_fact.object)
+            end
+          end
+        end
+      end
+    end
+  end
+end
+
+def assets_to_n3(assets)
+  "\n"+assets.map do |asset|
+    asset.facts.map do |fact|
+      ":#{asset.name}\t:#{fact.predicate}\t#{fact.object_asset.nil? ? fact.object: ':'+fact.object_asset.name} ."
+    end
+  end.flatten.join("\n")+"\n"
+end
+
+def assets_are_equal(expected_assets, obtained_assets)
+  expect(assets_equal?(expected_assets, obtained_assets)).to eq(true), "expected #{assets_to_n3(expected_assets)}, obtained #{assets_to_n3(obtained_assets)} shoud be equal"
+end
+
+def assets_are_different(expected_assets, obtained_assets)
+  expect(assets_equal?(expected_assets, obtained_assets)).to eq(false), "expected #{assets_to_n3(expected_assets)}, obtained #{assets_to_n3(obtained_assets)} should be different"
+end
+
+def check_inference(rule, input_facts, output_facts)
+  fail if input_facts.nil? || output_facts.nil? || rule.nil?
+  step_type = FactoryGirl.create(:step_type, :n3_definition => rule)
+
+  input_assets = SupportN3::parse_facts(input_facts, {}, false)
+  fail if input_assets.nil?
+  asset_group = FactoryGirl.create(:asset_group, {:assets => input_assets})
+
+  expected_output_assets = SupportN3::parse_facts(output_facts, {}, false)
+  fail if expected_output_assets.nil?
+
+  FactoryGirl.create(:step, {
+    :step_type => step_type,
+    :asset_group => asset_group
+  })
+
+  asset_group.assets.reload
+  obtained_output_assets = asset_group.assets
+
+  obtained_output_assets.each {|a| a.facts.reload}
+  assets_are_equal(expected_output_assets, obtained_output_assets)
+end
+
+RSpec.describe "Inference" do
+
+  describe '#inference' do
+    setup do
+    end
+
+    describe '#parse_facts' do
+      it 'creates assets from a N3 definition' do
+        code = %{
+          :tube1 :relates :tube2 .
+          :tube2 :name """a name""" .
+          :tube2 :volume """17""" .
+        }
+
+        obtained_assets = SupportN3::parse_facts(code)
+
+        tube1 = FactoryGirl.create(:asset, :name => 'tube1')
+        tube2 = FactoryGirl.create(:asset, :name => 'tube2')
+        tube3 = FactoryGirl.create(:asset)
+        tube4 = FactoryGirl.create(:asset, :name => 'tube4')
+        tube5 = FactoryGirl.create(:asset, :name => 'tube2')
+
+        tube1.facts << FactoryGirl.create(:fact, {:predicate => 'relates', :object_asset => tube2})
+        tube4.facts << FactoryGirl.create(:fact, {:predicate => 'relates', :object_asset => tube2})
+        tube2.facts << FactoryGirl.create(:fact, {:predicate => 'name', :object => 'a name'})
+        tube2.facts << FactoryGirl.create(:fact, {:predicate => 'volume', :object => '17'})
+        tube5.facts << FactoryGirl.create(:fact, {:predicate => 'volume', :object => '17'})
+
+        assets_are_equal([tube1], [tube1])
+
+        assets_are_equal([tube1, tube2], obtained_assets)
+        assets_are_different([tube3, tube2], obtained_assets)
+        assets_are_different([tube4, tube2], obtained_assets)
+        assets_are_different([tube1, tube5], obtained_assets)
+        assets_are_equal([tube2,tube1], [tube1, tube2])
+
+        assets_are_equal([tube1, tube1, tube2], [tube1, tube2])
+      end
+    end
+
+    inferences_data.each do |data|
+      if data[:it]
+        it data[:it] do
+          check_inference(data[:rule], data[:inputs], data[:outputs])
+        end
+      else
+        xit data[:xit] do
+          check_inference(data[:rule], data[:inputs], data[:outputs])
+        end
+      end
+    end
+
+  end
+end

--- a/spec/integration/inferences_data.rb
+++ b/spec/integration/inferences_data.rb
@@ -1,0 +1,301 @@
+def inferences_data
+[
+  {
+  :it => %Q{keeps elements the way they are when there is no changes},
+  :rule => %Q{ { ?x :t ?_y .} => { :step :addFacts {?x :t ?_y .}. }. },
+  :inputs => %Q{ :a :t """1""" . },
+  :outputs => %Q{ :a :t """1""" .}
+  },
+
+  {
+  :it => %Q{keeps elements the way they are when there is no changes},
+  :rule => %Q{ { ?x :t ?_y .} => { :step :addFacts {?x :t ?_y .}. }. },
+  :inputs => %Q{ :a :t """1""" . :b :t """2""".},
+  :outputs => %Q{ :a :t """1""" . :b :t """2""".}
+  },  
+  
+  {
+  :it => %Q{keeps elements the way they are when there is no changes},
+  :rule => %Q{ { ?x :relation_r ?_y .} => { :step :addFacts { ?x :relation_r ?_y . }. }. },
+  :inputs => %Q{ :a :relation_r """1""" . :b :relation_r :a .},
+  :outputs => %Q{ :a :relation_r """1""" . :b :relation_r :a .}
+  },
+  {
+  :it => %Q{relates elements with wildcard and with literal},
+  :rule => %Q{
+        {
+          ?x :s """1""" .          
+          ?y :t ?_val .
+        } => {
+          :step :addFacts {?x :val ?_val }.
+        }
+
+    },
+  :inputs => %Q{
+        :tube1 :s """1""" .        
+        :tube2 :t """2""" .        
+        :tube3 :s """1""" .        
+        :tube4 :t """2""" .        
+
+    },
+  :outputs => %Q{
+        :tube1 :s """1""" .        
+        :tube1 :val """2""" .        
+        :tube2 :t """2""" .        
+
+        :tube3 :s """1""" .        
+        :tube3 :val """2""" .        
+        :tube4 :t """2""" .        
+  }
+}, 
+{
+  :it => %Q{relates elements with wildcard},
+  :rule => %Q{
+        {
+          ?x :t ?_pos .
+          ?y :t ?_pos .
+        } => {
+          :step :addFacts {?x :relates_with ?y }.
+        }
+    },
+  :inputs => %Q{
+        :tube1 :t """1""" .        
+        :tube2 :t """2""" .        
+        :tube3 :t """1""" .        
+        :tube4 :t """2""" .        
+
+    },
+  :outputs => %Q{
+        :tube1 :t """1""" .
+        :tube2 :t """2""" .
+        :tube3 :t """1""" .
+        :tube4 :t """2""" .
+        :tube1 :relates_with :tube3 .
+        :tube3 :relates_with :tube1 .
+        :tube2 :relates_with :tube4 .
+        :tube4 :relates_with :tube2 .
+        :tube1 :relates_with :tube1 .
+        :tube2 :relates_with :tube2 .
+        :tube3 :relates_with :tube3 .
+        :tube4 :relates_with :tube4 .
+  }
+
+},
+{
+  :it => %Q{relates elements with relation},
+  :rule => %Q{
+        {
+          ?x :a :TubeA .
+          ?x :transfer ?y .
+          ?y :a :TubeB .
+        } => {
+          :step :addFacts { ?y :transferredFrom ?x . }.
+        }
+    },
+  :inputs => %Q{
+        :tube1 :a """TubeA""" .
+        :tube1 :transfer :tube2 .
+        :tube2 :a """TubeB""" .        
+
+    },
+  :outputs => %Q{
+        :tube1 :a """TubeA""" .
+        :tube2 :a """TubeB""" .        
+
+        :tube1 :transfer :tube2 .
+        :tube2 :transferredFrom :tube1 .
+  }
+},
+  {
+  :it => %Q{set the value if the destination does not have the value},
+  :rule => %Q{ 
+    { 
+      ?x :a :Tube .
+      ?y :a :Tube .
+      ?x :transfer ?y .
+      ?x :aliquotType ?_aliquot .
+      ?y :hasNotPredicate :aliquotType .
+    } => { 
+      :step :addFacts {?y :aliquotType ?_aliquot .}. 
+    }. 
+  },
+  :inputs => %Q{ 
+        :tube1 :a :Tube .
+        :tube1 :transfer :tube2 .
+        :tube2 :a :Tube .
+        :tube1 :aliquotType "DNA" .
+  },
+  :outputs => %Q{
+        :tube1 :a :Tube .
+        :tube1 :transfer :tube2 .
+        :tube2 :a :Tube .
+        :tube1 :aliquotType "DNA" .
+        :tube2 :aliquotType "DNA" .
+  }
+  },
+  {
+  :it => %Q{only set the value if the destination does not have the value already},
+  :rule => %Q{ 
+    { 
+      ?x :a :Tube .
+      ?y :a :Tube .
+      ?x :transfer ?y .
+      ?x :aliquotType ?_aliquot .
+      ?y :hasNotPredicate :aliquotType .
+    } => { 
+      :step :addFacts {?y :aliquotType ?_aliquot .}.
+    }. 
+  },
+  :inputs => %Q{ 
+        :tube1 :a :Tube .
+        :tube1 :transfer :tube2 .
+        :tube2 :a :Tube .
+        :tube1 :aliquotType """DNA""" .
+        :tube2 :aliquotType """RNA""" .
+  },
+  :outputs => %Q{
+        :tube1 :a :Tube .
+        :tube1 :transfer :tube2 .
+        :tube2 :a :Tube .
+        :tube1 :aliquotType """DNA""" .
+        :tube2 :aliquotType """RNA""" .
+  }
+  },
+  {
+  :it => %Q{transfer between plates},
+  :rule => %Q{ 
+    { 
+      ?x :a :Plate .
+      ?y :a :Plate .
+      ?x :transfer ?y .
+
+      ?x :contains ?a .
+      ?a :a :Tube .
+      ?y :contains ?b .
+      ?b :a :Tube .
+
+      ?a :location ?_location .
+      ?b :location ?_location .
+      ?a log:notEqualTo ?b .
+    } => { 
+      :step :addFacts {?a :transfer ?b .}.
+    }. 
+  },
+  :inputs => %Q{ 
+      :plate1 :a :Plate .
+      :plate2 :a :Plate .
+      :tube1 :a :Tube .
+      :tube2 :a :Tube .
+      :tube3 :a :Tube .
+
+      :plate1 :transfer :plate2 .
+      :plate1 :contains :tube1.
+      :plate2 :contains :tube2.
+      :tube1 :location "C10" .
+      :tube2 :location "C10" .
+      :tube3 :location "D9" .
+      :plate1 :contains :tube3 .
+  },
+  :outputs => %Q{
+      :plate1 :a :Plate .
+      :plate2 :a :Plate .
+      :tube1 :a :Tube .
+      :tube2 :a :Tube .
+      :tube3 :a :Tube .
+
+      :plate1 :transfer :plate2 .
+      :plate1 :contains :tube1.
+      :plate2 :contains :tube2.
+      :tube1 :location "C10" .
+      :tube2 :location "C10" .
+      :tube3 :location "D9" .
+      :plate1 :contains :tube3 .
+
+      :tube1 :transfer :tube2 .
+  }
+  },
+
+  {
+  :xit => %Q{perform math operations},
+  :rule => %Q{ 
+    { 
+      ?x :a :Plate .
+
+      ?x :contains ?a .
+      ?a :a :Well .
+      ?a :contains ?aliquot .
+      ?aliquot :a :Aliquot .
+      ?aliquot :currentVolume ?_volume .
+      (?_volume 10) math:sum ?_newVolume .
+    } => { 
+      :step :removeFacts {?aliquot :currentVolume ?_volume .}.
+      :step :addFacts {?aliquot :currentVolume ?newVolume .}.
+    }. 
+  },
+  :inputs => %Q{ 
+      :plate1 :a """Plate""" .
+      :well1 :a """Well""" .
+
+      :well1 :contains :aliquot1 .
+      :aliquot1 :a :Aliquot .
+      :aliquot1 :currentVolume """20""".
+
+  },
+  :outputs => %Q{
+      :plate1 :a """Plate""" .
+      :well1 :a """Well""" .
+
+      :well1 :contains :aliquot1 .
+      :aliquot1 :a :Aliquot .
+      :aliquot1 :currentVolume """30""".
+  }
+  },
+  {
+    :it => 'moves the value of a wildcard using a relation between two cgroups',
+    :rule => %Q{
+      {
+        ?tube :is :Tube .
+        ?tube :location ?_position .
+        ?rack :is :Rack .
+        ?rack :position ?_position .
+        ?rack :contains ?tube .
+        ?rack :relates ?tube .
+      } => {
+        :step :addFacts {?rack :is :TubeRack .} .
+        :step :addFacts {?rack :location ?_position .} .
+      }
+    },
+    :inputs => %Q{
+      :tube1 :is "Tube" , :Full ; :location "1".
+      :tube2 :is "Tube" , :Full ; :location "2".
+      :tube3 :is "Tube" , :Full ; :location "3".
+      :tube4 :is "Tube" , :Full ; :location "4".
+      :tube5 :is "Tube" , :Full ; :location "5".
+      :tube6 :is "Tube" , :Full ; :location "6".
+      :tube7 :is "Tube" , :Full ; :location "7".
+
+      :rack1 :is "Rack" , :Full ; :contains :tube1 ; :position "1" ; :relates :tube1 .
+      :rack2 :is "Rack" , :Full ; :contains :tube2 ; :position "2" ; :relates :tube2 .
+      :rack3 :is "Rack" , :Full ; :contains :tube3 ; :position "3" ; :relates :tube3 .
+      :rack4 :is "Rack" , :Full ; :contains :tube4 ; :position "4" ; :relates :tube4 .
+      :rack5 :is "Rack" , :Full ; :contains :tube5 ; :position "5" ; :relates :tube5 .
+    },
+    :outputs => %Q{
+      :tube1 :is "Tube" , :Full ; :location "1".
+      :tube2 :is "Tube" , :Full ; :location "2".
+      :tube3 :is "Tube" , :Full ; :location "3".
+      :tube4 :is "Tube" , :Full ; :location "4".
+      :tube5 :is "Tube" , :Full ; :location "5".
+      :tube6 :is "Tube" , :Full ; :location "6".
+      :tube7 :is "Tube" , :Full ; :location "7".
+
+      :rack1 :is "Rack" , "TubeRack" , :Full ; :contains :tube1 ; :position "1" ; :relates :tube1 ; :location "1" .
+      :rack2 :is "Rack" , "TubeRack" , :Full ; :contains :tube2 ; :position "2" ; :relates :tube2 ; :location "2" .
+      :rack3 :is "Rack" , "TubeRack" , :Full ; :contains :tube3 ; :position "3" ; :relates :tube3 ; :location "3" .
+      :rack4 :is "Rack" , "TubeRack" , :Full ; :contains :tube4 ; :position "4" ; :relates :tube4 ; :location "4" .
+      :rack5 :is "Rack" , "TubeRack" , :Full ; :contains :tube5 ; :position "5" ; :relates :tube5 ; :location "5" .
+    }
+  }
+
+]
+end

--- a/spec/models/step_spec.rb
+++ b/spec/models/step_spec.rb
@@ -137,46 +137,10 @@ RSpec.describe Step, type: :model do
             expect(Operation.all.count).to eq(2*@racks.count)
           end
 
-          it 'moves the value of a wildcard using a relation between two cgroups' do
-            @cg1.conditions << FactoryGirl.create(:condition, {:predicate => 'location',
-            :object_condition_group => @wildcard})
-            @cg2.conditions << FactoryGirl.create(:condition, {:predicate => 'relates',
-            :object_condition_group => @cg1})
-            @action = FactoryGirl.create(:action, {:action_type => 'addFacts',
-              :predicate => 'location', :object_condition_group => @wildcard,
-              :subject_condition_group => @cg2
-            })
-
-            @step_type.actions << @action
-
-            @tubes.each_with_index do |tube, idx|
-              tube.facts << FactoryGirl.create(:fact, {
-                :predicate => 'location',
-                :object => idx.to_s
-              })
-            end
-
-            @racks.each_with_index do |rack, idx|
-              rack.facts << FactoryGirl.create(:fact, {
-                :predicate => 'relates',
-                :object_asset => @tubes[idx]
-              })
-            end
-            @step = create_step
-
-            @racks.each(&:reload)
-            @tubes.each(&:reload)
-
-            @racks.each do |rack|
-              assert_equal rack.facts.with_predicate('location').count, 1
-              assert_equal rack.facts.with_predicate('location').first.object,
-                rack.facts.with_predicate('relates').first.object_asset.facts.with_predicate('location').first.object
-
-            end
-          end
-
-          xit 'uses the value of the condition group to relate different groups' do
+          it 'uses the value of the condition group to relate different groups' do
             # ?x :t ?pos . ?y :v ?pos . => ?x :relates ?y .
+            
+
             previous_num = @asset_group.assets.count
             @cg1.conditions << FactoryGirl.create(:condition, {:predicate => 'location',
             :object_condition_group => @wildcard})


### PR DESCRIPTION
at runtime
Wildcard values will use the values that are compatible with the values
of the rest of condition groups as well.
Assets can be wildcards
Runtime conditions are checked before applying a fact.
Dependency compatibility check to prune facts generated from an asset
whose parents are not compatible (inverse transitive check of conditions).
Added functionality to create assets from n3 format
N3 tests for inference engine.