### PR TITLE
Changed Transfer button to blue

### DIFF
--- a/app/assets/javascripts/templates/source_to_destination.jst.ejs
+++ b/app/assets/javascripts/templates/source_to_destination.jst.ejs
@@ -11,7 +11,7 @@
     <div class="row">
       <div class="col-md-12 with-bottom-margin">
         <button class="button btn btn-default reset-button">Reset</button>
-        <button class="button btn btn-default send-button">Transfer</button>
+        <button class="button btn btn-primary send-button">Transfer</button>
       </div>
     </div>
   </div>

--- a/app/models/asset/export.rb
+++ b/app/models/asset/export.rb
@@ -8,11 +8,12 @@ module Asset::Export
     SequencescapeClient.update_extraction_attributes(instance, attributes_to_update)
     facts.each {|f| f.update_attributes!(:up_to_date => true)}
     old_barcode = barcode
+    needs_print = old_barcode.nil? || old_barcode.empty?
     update_attributes(:uuid => instance.uuid, :barcode => instance.barcode.ean13)
     add_facts(Fact.create(:predicate => 'beforeBarcode', :object => old_barcode))
     facts.with_predicate('barcodeType').each(&:destroy)
     add_facts(Fact.create(:predicate => 'barcodeType', :object => 'SequencescapePlate'))
-    print(print_config, user.username)
+    print(print_config, user.username) if needs_print
   end
 
 

--- a/app/models/asset/import.rb
+++ b/app/models/asset/import.rb
@@ -19,7 +19,7 @@ module Asset::Import
         local_well.add_facts(Fact.create(:predicate => 'a', :object => 'Well'))
         local_well.add_facts(Fact.create(:predicate => 'location', :object => well.location))
         local_well.add_facts(Fact.create(:predicate => 'parent', :object_asset => asset))
-        local_well.add_facts(Fact.create(:predicate => 'aliquotType', :object => 'nap'))
+        #local_well.add_facts(Fact.create(:predicate => 'aliquotType', :object => 'nap'))
         annotate_container(local_well, well)
       end
     end

--- a/app/models/background_steps/update_sequencescape.rb
+++ b/app/models/background_steps/update_sequencescape.rb
@@ -20,11 +20,11 @@ class BackgroundSteps::UpdateSequencescape < Step
       if assets_compatible_with_step_type
         asset_group.assets.each do |asset|
           asset.update_sequencescape(printer_config, user)
-          removed_facts = asset.facts.select{|f| f.predicate == 'pushTo' && f.object == 'Sequencescape'}
-          asset.remove_operations(removed_facts, self)
-          removed_facts.select{|f| f.predicate == 'pushTo' && f.object == 'Sequencescape'}.each do |f|
-            f.destroy
-          end
+          #removed_facts = asset.facts.select{|f| f.predicate == 'pushTo' && f.object == 'Sequencescape'}
+          #asset.remove_operations(removed_facts, self)
+          #removed_facts.select{|f| f.predicate == 'pushTo' && f.object == 'Sequencescape'}.each do |f|
+          #  f.destroy
+          #end
         end
       end
     end

--- a/app/models/printables/group.rb
+++ b/app/models/printables/group.rb
@@ -16,7 +16,7 @@ module Printables::Group
     return if Rails.configuration.printing_disabled
     classify_for_printing(assets, printer_config).each do |printer_name, info_for_template|
       info_for_template.each do |label_template, assets|
-        body_print = assets.map{|a| a.printable_object(user)}.compact
+        body_print = assets.map{|a| a.printable_object(user)}.compact.reverse
         next if body_print.empty?
         PMB::PrintJob.new(
         printer_name:printer_name,

--- a/app/views/activities/show.html.erb
+++ b/app/views/activities/show.html.erb
@@ -6,7 +6,7 @@
 </div>
 <%= bootstrap_form_for @activity, action: 'show', :html => { :class => 'form-inline activity-desc' } do |f| %>
   <%= f.text_field :activity_type, :value => @activity.activity_type.name,:readonly => true %>
-  <%= f.text_field :instrument, :value => @activity.instrument.barcode,:readonly => true %>
+  <%= f.text_field :instrument, :value => @activity.instrument.name || @activity.instrument.barcode,:readonly => true %>
   <%= f.text_field :kit, :value => @activity.kit.barcode,:readonly => true %>
   <!-- %= f.text_field :tube_printer, :value => @current_user.tube_printer_name,:readonly => true %>
   < % = f.text_field :plate_printer, :value => @current_user.plate_printer_name,:readonly => true % -->

--- a/app/views/facts/_facts.html.erb
+++ b/app/views/facts/_facts.html.erb
@@ -2,7 +2,7 @@
   <span data-psd-component-class="RackWellDisplay" data-psd-component-parameters="<%= data_rack_display(facts) %>">
     <div class='svg '><%= svg Asset.class_type(facts) %></div>
     <div class="col-xs-10">
-  <% facts.each do |fact| %>
+  <% facts.unique.each do |fact| %>
     <%= render :partial => 'facts/fact', :locals => { :fact => fact} %>
   <% end %>
     </div>

--- a/app/views/facts/_facts.html.erb
+++ b/app/views/facts/_facts.html.erb
@@ -2,7 +2,7 @@
   <span data-psd-component-class="RackWellDisplay" data-psd-component-parameters="<%= data_rack_display(facts) %>">
     <div class='svg '><%= svg Asset.class_type(facts) %></div>
     <div class="col-xs-10">
-  <% facts.unique.each do |fact| %>
+  <% facts.uniq.each do |fact| %>
     <%= render :partial => 'facts/fact', :locals => { :fact => fact} %>
   <% end %>
     </div>

--- a/db/migrate/20170303142929_set_barcode_index_not_unique.rb
+++ b/db/migrate/20170303142929_set_barcode_index_not_unique.rb
@@ -1,0 +1,6 @@
+class SetBarcodeIndexNotUnique < ActiveRecord::Migration
+  def change
+    remove_index :assets, :barcode
+    add_index :assets, :barcode
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20170302135104) do
+ActiveRecord::Schema.define(version: 20170303142929) do
 
   create_table "actions", force: :cascade do |t|
     t.string   "action_type",                limit: 255, null: false
@@ -131,7 +131,7 @@ ActiveRecord::Schema.define(version: 20170302135104) do
     t.integer  "facts_count", limit: 4
   end
 
-  add_index "assets", ["barcode"], name: "index_assets_on_barcode", unique: true, using: :btree
+  add_index "assets", ["barcode"], name: "index_assets_on_barcode", using: :btree
 
   create_table "assets_facts", force: :cascade do |t|
     t.integer  "asset_id",   limit: 4

--- a/lib/workflows/qiacube.n3
+++ b/lib/workflows/qiacube.n3
@@ -3,24 +3,24 @@
   ?tube   :a  :SampleTube .
   ?tube   :is   :NotStarted .
   ?tube   :maxCardinality   """12""" .
-  ?tube_dna   :maxCardinality   """0""" .
-  ?tube_nap   :maxCardinality   """0""" .
+  ?dna_tube   :maxCardinality   """0""" .
+  ?rnap_tube   :maxCardinality   """0""" .
 } => {
   :step :addFacts {
     ?tube   :groupNamePrefix """"Sample tubes""" .
   }.
-  :step  :stepTypeName """Create DNA and NA+P tubes from Sample tubes""" .
+  :step  :stepTypeName """Create DNA and RNA+P tubes from Sample tubes""" .
   :step  :createAsset  {
-    ?tube_dna   :a  :Tube .
-    ?tube_dna   :aliquotType  :DNA .
-    ?tube_dna   :is  :Empty .
-    ?tube_dna   :groupNamePrefix """"DNA tubes""" .    
+    ?dna_tube   :a  :Tube .
+    ?dna_tube   :aliquotType  :DNA .
+    ?dna_tube   :is  :Empty .
+    ?dna_tube   :groupNamePrefix """"DNA tubes""" .    
   } .
   :step  :createAsset  {
-    ?tube_nap   :a  :Tube .
-    ?tube_nap   :aliquotType  :NAP .
-    ?tube_nap   :is :Empty .
-    ?tube_nap   :groupNamePrefix """"NA+P tubes""" .    
+    ?rnap_tube   :a  :Tube .
+    ?rnap_tube   :aliquotType  :RNAP .
+    ?rnap_tube   :is :Empty .
+    ?rnap_tube   :groupNamePrefix """"RNA+P tubes""" .    
   } .
 } .
 
@@ -29,22 +29,22 @@
   ?tube   :is :NotStarted .
   ?tube   :maxCardinality   """12""" .
   ?tube   :sanger_sample_id ?_sample .
-  ?tube_dna   :a  :Tube .
-  ?tube_dna   :aliquotType  :DNA .
-  ?tube_dna   :maxCardinality   """12""" .
-  ?tube_nap   :a  :Tube .
-  ?tube_nap   :aliquotType  :NAP .
-  ?tube_nap   :maxCardinality   """12""" .
+  ?dna_tube   :a  :Tube .
+  ?dna_tube   :aliquotType  :DNA .
+  ?dna_tube   :maxCardinality   """12""" .
+  ?rnap_tube   :a  :Tube .
+  ?rnap_tube   :aliquotType  :RNAP .
+  ?rnap_tube   :maxCardinality   """12""" .
 } => {
-  :step  :stepTypeName """Extract DNA and NA+P from Sample tubes""" .
+  :step  :stepTypeName """Extract DNA and RNA+P from Sample tubes""" .
   :step  :stepTemplate """transfer_tube_to_tube""" .
   :step  :unselectAsset  ?tube .
-  :step  :removeFacts {?tube_dna :is :Empty.}.
-  :step  :removeFacts {?tube_nap :is :Empty.}.
-  :step  :addFacts   { ?tube   :transfer   ?tube_dna .} .
-  :step  :addFacts   { ?tube   :transfer   ?tube_nap .} .
-  :step  :addFacts   { ?tube_dna   :transferredFrom  ?tube .} .
-  :step  :addFacts   { ?tube_nap   :transferredFrom  ?tube .} .
+  :step  :removeFacts {?dna_tube :is :Empty.}.
+  :step  :removeFacts {?rnap_tube :is :Empty.}.
+  :step  :addFacts   { ?tube   :transfer   ?dna_tube .} .
+  :step  :addFacts   { ?tube   :transfer   ?rnap_tube .} .
+  :step  :addFacts   { ?dna_tube   :transferredFrom  ?tube .} .
+  :step  :addFacts   { ?rnap_tube   :transferredFrom  ?tube .} .
   :step :addFacts {?tube :is :Started.}.
   :step :removeFacts {?tube :is :NotStarted.}.
 } .
@@ -54,50 +54,50 @@
   ?tube   :is   :NotStarted .
   ?tube   :sanger_sample_id ?_sample .
   ?tube   :maxCardinality   """12""" .
-  ?tube_dna   :maxCardinality   """12""" .
-  ?tube_nap   :maxCardinality   """12""" .
+  ?dna_tube   :maxCardinality   """12""" .
+  ?rnap_tube   :maxCardinality   """12""" .
 } => {
-  :step  :stepTypeName """(BY POSITION) Create and Extract DNA and NA+P from Sample tubes""" .
+  :step  :stepTypeName """(BY POSITION) Create and Extract DNA and RNA+P from Sample tubes""" .
   :step :connectBy """position""" .  
   :step  :createAsset  {
-    ?tube_dna :a  :Tube .
-    ?tube_dna :aliquotType  :DNA .
-    ?tube_dna :transferredFrom ?tube .
+    ?dna_tube :a  :Tube .
+    ?dna_tube :aliquotType  :DNA .
+    ?dna_tube :transferredFrom ?tube .
   } .
   :step  :createAsset  {
-    ?tube_nap   :a  :Tube .
-    ?tube_nap   :aliquotType  :NAP .
-    ?tube_nap :transferredFrom ?tube .
+    ?rnap_tube   :a  :Tube .
+    ?rnap_tube   :aliquotType  :RNAP .
+    ?rnap_tube :transferredFrom ?tube .
   } .
   :step  :unselectAsset   ?tube.
   :step :connectBy """position""" .
-  :step  :addFacts   { ?tube   :transfer   ?tube_dna .} .
-  :step  :addFacts   { ?tube   :transfer   ?tube_nap .} .
+  :step  :addFacts   { ?tube   :transfer   ?dna_tube .} .
+  :step  :addFacts   { ?tube   :transfer   ?rnap_tube .} .
   :step  :addFacts   { ?tube :is :Started. }.
   :step :removeFacts { ?tube :is :NotStarted.}.
 } .
 
 
 {
-  ?tube_dna   :aliquotType  :DNA .
-  ?tube_dna   :sanger_sample_id  ?_sample .
-  ?tube_dna   :maxCardinality   """0""" .
-  ?tube_nap   :aliquotType  :NAP .
-  ?tube_nap   :maxCardinality   """0""" .
+  ?dna_tube   :aliquotType  :DNA .
+  ?dna_tube   :sanger_sample_id  ?_sample .
+  ?dna_tube   :maxCardinality   """0""" .
+  ?rnap_tube   :aliquotType  :RNAP .
+  ?rnap_tube   :maxCardinality   """0""" .
 } => {
   :step  :stepTypeName """Select just DNA tubes""" .
-  :step  :unselectAsset  ?tube_nap.
+  :step  :unselectAsset  ?rnap_tube.
 } .
 
 {
-  ?tube_dna   :aliquotType  :DNA .
-  ?tube_dna   :maxCardinality   """0""" .
-  ?tube_nap   :aliquotType  :NAP .
-  ?tube_nap   :sanger_sample_id  ?_sample .
-  ?tube_nap   :maxCardinality   """0""" .
+  ?dna_tube   :aliquotType  :DNA .
+  ?dna_tube   :maxCardinality   """0""" .
+  ?rnap_tube   :aliquotType  :RNAP .
+  ?rnap_tube   :sanger_sample_id  ?_sample .
+  ?rnap_tube   :maxCardinality   """0""" .
 } => {
-  :step  :stepTypeName """Select just NA+P tubes""" .
-  :step  :unselectAsset  ?tube_dna.
+  :step  :stepTypeName """Select just RNA+P tubes""" .
+  :step  :unselectAsset  ?dna_tube.
   } .
 
 {
@@ -120,10 +120,10 @@
   ?tube  :maxCardinality   """12""" .
   ?rna_tube  :maxCardinality   """0""" .
 } => {
-  :step  :stepTypeName """Create NA+P tube from Sample tube""" .
+  :step  :stepTypeName """Create RNA+P tube from Sample tube""" .
   :step  :createAsset  {
     ?rna_tube  :a  :Tube .
-    ?rna_tube  :aliquotType  :NAP .
+    ?rna_tube  :aliquotType  :RNAP .
     ?rna_tube  :is :Empty .
   } .
 } .
@@ -150,15 +150,15 @@
 {
   ?tube   :a  :SampleTube .
   ?tube  :is   :NotStarted .  
-  ?tube   :aliquotType :NAP .
+  ?tube   :aliquotType :RNAP .
   ?tube   :sanger_sample_id ?_sample .
   ?tube   :maxCardinality   """0""" .
   ?rna_tube   :a  :Tube .
-  ?rna_tube   :aliquotType  :NAP .
+  ?rna_tube   :aliquotType  :RNAP .
   ?rna_tube   :is  :Empty .
   ?rna_tube   :maxCardinality   """12""" .
 } => {
-  :step  :stepTypeName """Extract NA+P for RNA only""" .
+  :step  :stepTypeName """Extract RNA+P for RNA only""" .
   :step  :stepTemplate """transfer_tube_to_tube""" .
   :step  :removeFacts {?rna_tube :is :Empty.}.
   :step  :addFacts   {?tube   :transfer   ?rna_tube .} .
@@ -166,14 +166,14 @@
 } .
 
 {
-  ?nap_tube       :a  :Tube .
-  ?nap_tube   :aliquotType   :NAP .
-  ?nap_tube   :maxCardinality   """12""" .
+  ?rnap_tube       :a  :Tube .
+  ?rnap_tube   :aliquotType   :RNAP .
+  ?rnap_tube   :maxCardinality   """12""" .
   ?rna_tube   :maxCardinality   """0""" .
 } => {
-  ?nap_tube  :groupName """NA+P tube""" .
+  ?rnap_tube  :groupName """NA+P tube""" .
   ?rna_tube  :groupName """RNA tube""" .
-  :step  :stepTypeName """Create RNA tubes from NA+P tubes""" .
+  :step  :stepTypeName """Create RNA tubes from RNA+P tubes""" .
   :step  :createAsset  {
     ?rna_tube   :a  :Tube .
     ?rna_tube   :aliquotType  :RNA .
@@ -182,31 +182,49 @@
 } .
 
 {
-  ?nap_tube   :a  :Tube .
-  ?nap_tube   :aliquotType :NAP .
-  ?nap_tube   :sanger_sample_id ?_sample .
-  ?nap_tube   :maxCardinality   """12""" .
+  ?rnap_tube   :a  :Tube .
+  ?rnap_tube   :aliquotType :RNAP .
+  ?rnap_tube   :sanger_sample_id ?_sample .
+  ?rnap_tube   :maxCardinality   """12""" .
   ?rna_tube   :maxCardinality   """12""" .
 } => {
-  :step  :stepTypeName """(BY POSITION) Create RNA and extract RNA from NA+P tubes""" .
+  :step  :stepTypeName """(BY POSITION) Create RNA and extract RNA from RNA+P tubes""" .
   :step :connectBy """position""" .
   :step  :createAsset  {
     ?rna_tube   :a  :Tube .
     ?rna_tube   :aliquotType  :RNA .
-    ?rna_tube   :transferredFrom  ?nap_tube .
+    ?rna_tube   :transferredFrom  ?rnap_tube .
   } .
-  :step  :addFacts   {?nap_tube   :transfer   ?rna_tube .} .
+  :step  :addFacts   {?rnap_tube   :transfer   ?rna_tube .} .
 } .
 
 {
-  ?nap_tube   :a  :Tube .
-  ?nap_tube   :aliquotType :NAP .
+  ?rnap_tube   :a  :Tube .
+  ?rnap_tube   :aliquotType :RNAP .
+  ?rnap_tube   :sanger_sample_id ?_sample .
+  ?rnap_tube   :maxCardinality   """12""" .
+  ?rna_tube   :maxCardinality   """12""" .
+  ?rna_tube   :is :Empty .
+} => {
+  :step  :stepTypeName """Extract RNA from RNA+P tubes""" .
+  :step :connectBy """position""" .
+  :step  :addFacts  {
+    ?rna_tube   :aliquotType  :RNA .
+    ?rna_tube   :transferredFrom  ?rnap_tube .
+  } .
+  :step  :addFacts   {?rnap_tube   :transfer   ?rna_tube .} .
+  :step  :removeFacts {?rna_tube :is :Empty .}.
+} .
+
+{
+  ?rnap_tube   :a  :Tube .
+  ?rnap_tube   :aliquotType :RNAP .
   ?rna_tube   :a  :Tube .
   ?rna_tube   :aliquotType  :RNA .
   ?rna_tube   :sanger_sample_id ?_sample .
 }=>{
   :step :stepTypeName """Select only RNA tubes""".
-  :step :unselectAsset ?nap_tube .
+  :step :unselectAsset ?rnap_tube .
 }.
 
 
@@ -287,31 +305,31 @@
 {
   ?tube :a :Tube .
   ?tube :aliquotType :DNA .
-  ?rack :maxCardinality """1""" .
+  ?rack_dna :maxCardinality """1""" .
   ?tube :maxCardinality """96""" .
 }=>{
   :step :stepTypeName """Create TubeRack for DNA""" .
   :step :createAsset {
-    ?rack :a :TubeRack . 
-    ?rack :barcodeType :NoBarcode .
-    ?rack :createdFrom ?tube .
+    ?rack_dna :a :TubeRack . 
+    ?rack_dna :barcodeType :NoBarcode .
+    ?rack_dna :createdFrom ?tube .
   }.
-  :step :addFacts {?tube :creates ?rack .}.
+  :step :addFacts {?tube :creates ?rack_dna .}.
 }.
 
 {
   ?tube :a :Tube .
   ?tube :aliquotType :RNA .
-  ?rack :maxCardinality """1""" .
+  ?rack_rna :maxCardinality """1""" .
   ?tube :maxCardinality """96""" .
 }=>{
   :step :stepTypeName """Create TubeRack for RNA""" .
   :step :createAsset {
-    ?rack :a :TubeRack . 
-    ?rack :barcodeType :NoBarcode .
-    ?rack :createdFrom ?tube .
+    ?rack_rna :a :TubeRack . 
+    ?rack_rna :barcodeType :NoBarcode .
+    ?rack_rna :createdFrom ?tube .
   }.
-  :step :addFacts {?tube :creates ?rack .}.
+  :step :addFacts {?tube :creates ?rack_rna .}.
 }.
 
 {

--- a/spec/integration/inference_spec.rb
+++ b/spec/integration/inference_spec.rb
@@ -15,20 +15,31 @@ RSpec.describe "Inference" do
 
         obtained_assets = SupportN3::parse_facts(code)
 
-        tube1 = FactoryGirl.create(:asset, :name => 'tube1')
-        tube2 = FactoryGirl.create(:asset, :name => 'tube2')
+        f1 = [
+            FactoryGirl.create(:fact, {:predicate => 'name', :object => 'a name'}),
+            FactoryGirl.create(:fact, {:predicate => 'volume', :object => '17'})]
+        tube2 = FactoryGirl.create(:asset, :name => 'tube2', :facts => f1)
+        f2 = [
+          FactoryGirl.create(:fact, {:predicate => 'relates', :object_asset => tube2})
+        ]
+        tube1 = FactoryGirl.create(:asset, :name => 'tube1', :facts=> f2)
         tube3 = FactoryGirl.create(:asset)
-        tube4 = FactoryGirl.create(:asset, :name => 'tube4')
-        tube5 = FactoryGirl.create(:asset, :name => 'tube2')
+        f3 = [
+          FactoryGirl.create(:fact, {:predicate => 'relates', :object_asset => tube2})
+        ]
+        tube4 = FactoryGirl.create(:asset, :name => 'tube4', 
+          :facts => f3
+        )
+        f4 = [FactoryGirl.create(:fact, {:predicate => 'volume', :object => '17'})]
+        tube5 = FactoryGirl.create(:asset, :name => 'tube2',
+          :facts => f4)
 
-        tube1.facts << FactoryGirl.create(:fact, {:predicate => 'relates', :object_asset => tube2})
-        tube4.facts << FactoryGirl.create(:fact, {:predicate => 'relates', :object_asset => tube2})
-        tube2.facts << FactoryGirl.create(:fact, {:predicate => 'name', :object => 'a name'})
-        tube2.facts << FactoryGirl.create(:fact, {:predicate => 'volume', :object => '17'})
-        tube5.facts << FactoryGirl.create(:fact, {:predicate => 'volume', :object => '17'})
+        obtained_assets.each do |t|
+          t.reload
+          t.facts.reload
+        end
 
         assets_are_equal([tube1], [tube1])
-
         assets_are_equal([tube1, tube2], obtained_assets)
         assets_are_different([tube3, tube2], obtained_assets)
         assets_are_different([tube4, tube2], obtained_assets)


### PR DESCRIPTION
Only prints the Sequencescape barcode if the barcode has been generated
Not tag imported wells as rnap
Do not remove Sequencescape pushTo, so the Plate will always upload its changes
to Sequencescape
Printed list of barcodes will appear in reverse order
Instrument name instead of instrument barcode.
Unique list of facts on display.
Database index for barcode won't keep unique values
Changed dna_tube and nap_tube to dna_tube and rnap_tube
Removed step Extract RNA from RNA+P only from the by position