### PR TITLE
Inheritable attributes from tubes into plates

### DIFF
--- a/app/javascript/components/activity.jsx
+++ b/app/javascript/components/activity.jsx
@@ -121,7 +121,7 @@ class Activity extends React.Component {
     return msg
   }
   changeAssetGroup(assetGroup, data) {
-    this.activityChannel.send(data)
+    return this.activityChannel.send(data)
   }
   getAssetUuidsForAssetGroup(assetGroup) {
     return assetGroup.assets.map((a) => a.uuid)

--- a/app/javascript/components/asset_group_components/asset_group_editor.jsx
+++ b/app/javascript/components/asset_group_components/asset_group_editor.jsx
@@ -75,10 +75,8 @@ class AssetGroupEditor extends React.Component {
   onSubmit(e) {
     e.preventDefault()
     this.setState({disabledBarcodesInput: true})
-    return this.props
-      .onAddBarcodesToAssetGroup(this.props.assetGroup, this.state.barcodesInputText)
-      //.then(this.onAjaxSuccess)
-      .finally(this.onAjaxComplete)
+    this.props.onAddBarcodesToAssetGroup(this.props.assetGroup, this.state.barcodesInputText)
+    this.onAjaxComplete()
   }
   assetsChanging() {
     return Object.keys(this.state.assets_status).filter($.proxy(function(uuid) {

--- a/app/models/step_type.rb
+++ b/app/models/step_type.rb
@@ -27,9 +27,9 @@ class StepType < ActiveRecord::Base
     select{|stype| stype.task_type == task_type }
   end
 
-  scope :for_reasoning, ->() { where(:for_reasoning => true).order(priority: :desc)}
+  scope :for_reasoning, ->() { not_deprecated.where(:for_reasoning => true).order(priority: :desc)}
 
-  scope :not_for_reasoning, ->() { where(:for_reasoning => false) }
+  scope :not_for_reasoning, ->() { not_deprecated.where(:for_reasoning => false) }
 
   def touch_activities
     activities.each do |activity|

--- a/script/runners/put_tubes_into_rack_by_column_order.rb
+++ b/script/runners/put_tubes_into_rack_by_column_order.rb
@@ -1,0 +1,41 @@
+require 'actions/racking'
+include Actions::Racking
+
+return unless ARGV.any?{|s| s.match(".json")}
+
+updates = FactChanges.new
+
+def location_for_position(i)
+  letters = ("A".."H").to_a
+  columns = (1..12).to_a
+  "#{letters[(i%letters.length).floor]}#{(columns[i/letters.length]).to_s}"
+end
+
+args = ARGV[0]
+out({}) unless args
+matches = args.match(/(\d*)\.json/)
+out({}) unless matches
+asset_group_id = matches[1]
+asset_group = AssetGroup.find(asset_group_id)
+rack = asset_group.assets.joins(:facts).where(facts: { predicate: 'a', object: 'TubeRack'}).first
+tube_ids_in_rack = rack.facts.with_predicate('contains').map(&:object_asset_id)
+locations_with_tube = Fact.where(predicate: 'location', asset_id: tube_ids_in_rack).map(&:object)
+
+tubes = asset_group.assets.joins(:facts).where(facts: { predicate: 'a', object: 'Tube'})
+
+all_locations = 96.times.map{|i| location_for_position(i)}
+available_locations = all_locations - locations_with_tube
+
+if available_locations.length < tubes.length
+  updates.set_error('There are not enough locations available for the tubes')
+else
+  layout = tubes.each_with_index.reduce([]) do |memo, list|
+    tube = list[0]
+    idx = list[1]
+    location = available_locations[idx]
+    memo.push(asset: tube, location: available_locations[idx])
+  end
+  updates.merge(Actions::Racking::reracking_tubes(rack, layout))
+end
+
+puts updates.to_json


### PR DESCRIPTION
JS Bugfix, change asset group is not returning a promise anymore
Reasoning tasks will not include deprecated tasks
Purpose, aliquot type and study name will be inherited by the plate from
the tubes.
On reracking, if the rack does not contain a tube with those properties
anymore, it will dissappear from its list of facts.